### PR TITLE
autodetect MI type

### DIFF
--- a/NRF24_DTUMIesp.ino
+++ b/NRF24_DTUMIesp.ino
@@ -73,7 +73,7 @@ static Serial_header_t SerialHdr;
 static uint16_t lastCRC;
 static uint16_t crc;
 
-static uint8_t channels[] = {3,23, 40, 61, 75};   //{1, 3, 6, 9, 11, 23, 40, 61, 75}
+static uint8_t channels[] = {3, 23, 40, 61, 75};   //{1, 3, 6, 9, 11, 23, 40, 61, 75}
 static uint8_t TxChId = 0;
 static uint8_t RxChId = 0;                         // fange mit 3 an
 static uint8_t TxCH   = channels[TxChId];
@@ -355,7 +355,28 @@ void setup(void) {
   UpdateMqttTick = millis() + 200;
   if (WITHWIFI)
       STARTTIME=(String)getDateStr(getNow())+" "+(String)getTimeStr(getNow());
-
+  
+  uint64_t sn = SerialWR;
+  longlongasbytes llsn;
+  llsn.ull = sn;
+  if(llsn.bytes[5] == 0x10) {
+  switch(llsn.bytes[4]) {
+    case 0x21: 
+        { MI300 = 1; MI600 = 0; MI1500 = 0; 
+        if (NRofPV==0) { NRofPV = 1; } 
+        break; }
+    case 0x41: 
+        { MI600 = 1; MI300 = 0; MI1500 = 0; 
+        if (NRofPV==0) { NRofPV = 2; } 
+        break; }
+    case 0x61: 
+        { MI1500 = 1; MI600 = 0; MI300 = 0; 
+        if (NRofPV==0) { NRofPV = 4; }
+        break; }
+  }
+  MAXPOWER = NRofPV * PVPOWER;   
+  MINPOWER = int(MAXPOWER / 10);
+  }
   if (MI300) strcpy(MIWHAT,"MI-300");
   if (MI600) strcpy(MIWHAT,"MI-600");
   if (MI1500) strcpy(MIWHAT,"MI-1500");

--- a/Settings.h
+++ b/Settings.h
@@ -17,7 +17,7 @@ Alle Einstellungen sind in Settings.h UND secrets.h !!
 // Hardware configuration, CHECK THIS OUT with your board !!!!!!!!!!!!!!!!!!!!!!!!!!
 // ESP8266 PIN Setting====================================================================================
 #ifdef ESP8266
-    #define RF1_CE_PIN  (D2) //(D2)
+    #define RF1_CE_PIN  (D4) //(D2)
     #define RF1_CS_PIN  (D8) //(D8)
     #define RF1_IRQ_PIN (D3)
 //GPIO0  D3 -> IRQ
@@ -48,13 +48,13 @@ int WR_LIMITTED     = 0;    //fixed limiting in Watt. if you dont want fixed lim
 bool MI300  = 0;     //<<<<<<<<<<<< choose which model of Hoymiles MI microinverter
 bool MI600  = 0;     //choose this for TSUN TSOL-M800 also
 bool MI1500 = 1;
-#define NRofPV  3   //<<<<<<<<<<<< number of PV panels in use (connected) 1-4. (not the number of WR-ports)
+int  NRofPV = 0;    //<<<<<<<<<<<< number of PV panels in use (connected) 1-4. (0 to set automatically to the number of WR-ports)
                     //assume the ports are connected in order from 1 to 4
                     //we have to know how many PVs are really connected to WR.
                     //if we know it, we dont have to wait of all ports!
 
 // Webserver ..................................,,,,,,...........................................
-IPAddress ROUTER = IPAddress(192,168,1,1);       // your routers IP???
+IPAddress ROUTER = IPAddress(192,168,2,1);       // your routers IP???
 #define WEBSERVER_PORT      80
 
 // Time Server .............................,,,,................................................
@@ -62,7 +62,7 @@ IPAddress ROUTER = IPAddress(192,168,1,1);       // your routers IP???
 //#define TIMESERVER_NAME "fritz.box"
 
 // MQTT ........................................................................................
-const char MQTTbroker[] = "192.168.1.11";
+const char MQTTbroker[] = "192.168.2.72";
 int        MQTTport     = 1883;
 char       MQTTclientid[] = "MYDTU";
 // END OF YOUR CONFIGURATION ===================================================================


### PR DESCRIPTION
(based on serial nr)
Tested for MI1500 and MI600 serial nr. 

NRofPV will be detected automatically as well, if not set manual in Settings.h, seems to work.

